### PR TITLE
Fixed a bug where plugin causes PHP crash on manual new order in WC

### DIFF
--- a/includes/order-rules/rule-set.php
+++ b/includes/order-rules/rule-set.php
@@ -50,39 +50,38 @@ if (!class_exists('TRUNKRS_WC_RuleSet')) {
 
         $firstShippingItem = TRUNKRS_WC_Utils::firstInIterable($wrapper->order->get_items('shipping'));
 
-        if ( !is_null($firstShippingItem) ) {
-          $shipping = $firstShippingItem->get_data();
-          $data = $wrapper->order->get_data();
+        if (is_null($firstShippingItem))
+          return false;
 
-          foreach ($this->fields as $field => $rules) {
-            $value = key_exists($field, $data) ? $data[$field] : null;
-            if (!isset($value))
-              $value = key_exists($field, $shipping) ? $shipping[$field] : null;
-            if (!isset($value))
-              $value = $wrapper->order->get_meta($field);
+        $shipping = $firstShippingItem->get_data();
+        $data = $wrapper->order->get_data();
 
-            if (!isset($value)) {
-              return false;
-            }
+        foreach ($this->fields as $field => $rules) {
+          $value = key_exists($field, $data) ? $data[$field] : null;
+          if (!isset($value))
+            $value = key_exists($field, $shipping) ? $shipping[$field] : null;
+          if (!isset($value))
+            $value = $wrapper->order->get_meta($field);
 
-            $booleanCounter = 0;
-
-            foreach ($rules as $rule) {
-              $matches = $rule->matches($value);
-              $auditLog->createEntry($field, $value)->setResult($rule, $matches);
-
-              $booleanCounter += $matches;
-            }
-
-            if ($booleanCounter === 0) {
-              return false;
-            }
+          if (!isset($value)) {
+            return false;
           }
 
-          return true;
+          $booleanCounter = 0;
+
+          foreach ($rules as $rule) {
+            $matches = $rule->matches($value);
+            $auditLog->createEntry($field, $value)->setResult($rule, $matches);
+
+            $booleanCounter += $matches;
+          }
+
+          if ($booleanCounter === 0) {
+            return false;
+          }
         }
-        
-        return false;
+
+        return true;
       } finally {
         if ($withLog) {
           $auditLog->saveLog();

--- a/includes/order-rules/rule-set.php
+++ b/includes/order-rules/rule-set.php
@@ -51,7 +51,7 @@ if (!class_exists('TRUNKRS_WC_RuleSet')) {
         $firstShippingItem = TRUNKRS_WC_Utils::firstInIterable($wrapper->order->get_items('shipping'));
 
         if ( !is_null($firstShippingItem) ) {
-            $shipping = TRUNKRS_WC_Utils::firstInIterable($wrapper->order->get_items('shipping'))->get_data();
+            $shipping = $firstShippingItem->get_data();
             $data = $wrapper->order->get_data();
 
             foreach ($this->fields as $field => $rules) {

--- a/includes/order-rules/rule-set.php
+++ b/includes/order-rules/rule-set.php
@@ -51,35 +51,35 @@ if (!class_exists('TRUNKRS_WC_RuleSet')) {
         $firstShippingItem = TRUNKRS_WC_Utils::firstInIterable($wrapper->order->get_items('shipping'));
 
         if ( !is_null($firstShippingItem) ) {
-            $shipping = $firstShippingItem->get_data();
-            $data = $wrapper->order->get_data();
+          $shipping = $firstShippingItem->get_data();
+          $data = $wrapper->order->get_data();
 
-            foreach ($this->fields as $field => $rules) {
+          foreach ($this->fields as $field => $rules) {
             $value = key_exists($field, $data) ? $data[$field] : null;
             if (!isset($value))
-                $value = key_exists($field, $shipping) ? $shipping[$field] : null;
+              $value = key_exists($field, $shipping) ? $shipping[$field] : null;
             if (!isset($value))
-                $value = $wrapper->order->get_meta($field);
+              $value = $wrapper->order->get_meta($field);
 
             if (!isset($value)) {
-                return false;
+              return false;
             }
 
             $booleanCounter = 0;
 
             foreach ($rules as $rule) {
-                $matches = $rule->matches($value);
-                $auditLog->createEntry($field, $value)->setResult($rule, $matches);
+              $matches = $rule->matches($value);
+              $auditLog->createEntry($field, $value)->setResult($rule, $matches);
 
-                $booleanCounter += $matches;
+              $booleanCounter += $matches;
             }
 
             if ($booleanCounter === 0) {
-                return false;
+              return false;
             }
-            }
+          }
 
-            return true;
+          return true;
         }
         
         return false;


### PR DESCRIPTION
**Origin**
Trunkrs Woocommerce plugin causes crash on manual new order in WC backend. Error below. 

**PHP error**
`PHP Fatal error:  Uncaught Error: Call to a member function get_data() on null in /Users/bas/Alterio/broodbutler/framework/plugins/trunkrs-for-woocommerce/includes/order-rules/rule-set.php:51
Stack trace:`

**Fix**
This quick fix checks if `get_data()` function is not being called upon `null`. Not sure what the impact is, but at least manual order creation works. Can we maybe set shipping date in a field?